### PR TITLE
Add image and caption styles

### DIFF
--- a/mdStyles.css
+++ b/mdStyles.css
@@ -56,4 +56,9 @@ img {
 
 /* #region Custom classes */
 .center { text-align: center; }
+
+p.caption {
+    margin-top: -14px;
+    break-before: avoid;
+}
 /* #endregion Custom classes */

--- a/mdStyles.css
+++ b/mdStyles.css
@@ -46,6 +46,12 @@ pre {
     background-color: var(--vscode-textCodeBlock-background);
     border: 1px solid var(--vscode-widget-border);
 }
+
+img {
+    background-color: var(--vscode-textBlockQuote-background);
+    padding: 5px;
+    border-radius: 4px;
+}
 /* #endregion Inline and Fenced code */
 
 /* #region Custom classes */


### PR DESCRIPTION
Added styles for `img` and `p.caption`

* Images now have a rounded, padded, shaded background

* Paragraphs with the `caption` class have negative upper margin and avoid breaks before them